### PR TITLE
Merge upstream cloudflare/master (supersedes #21)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,24 +1,30 @@
+name: Semgrep OSS scan
 on:
   pull_request: {}
+  push:
+    branches: [main, master]
   workflow_dispatch: {}
-  push: 
-    branches:
-      - main
-      - master
   schedule:
-    - cron: '0 0 * * *'
-name: Semgrep config
+    - cron: '0 0 20 * *'
+concurrency:
+  group: semgrep-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   semgrep:
-    name: semgrep/ci
-    runs-on: ubuntu-latest
-    env:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-      SEMGREP_URL: https://cloudflare.semgrep.dev
-      SEMGREP_APP_URL: https://cloudflare.semgrep.dev
-      SEMGREP_VERSION_CHECK_URL: https://cloudflare.semgrep.dev/api/check-version
-    container:
-      image: semgrep/semgrep
+    name: semgrep-oss
+    runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v4
-      - run: semgrep ci
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - id: cache-semgrep
+        uses: actions/cache@v5
+        with:
+          path: ~/.local
+          key: semgrep-1.160.0-${{ runner.os }}
+      - if: steps.cache-semgrep.outputs.cache-hit != 'true'
+        run: pip install --user semgrep==1.160.0
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: semgrep scan --config=auto

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,9 +732,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ js-sys = "0.3.85"
 libc = "0.2.182"
 memchr = "2.8.0"
 num_enum = "0.7.5"
-rand = "0.9.2"
+rand = "0.9.3"
 regex-automata = "0.4.14"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -799,7 +799,7 @@ mod tests {
     use crate::ast::logical_expr::LogicalExpr;
     use crate::execution_context::ExecutionContext;
     use crate::functions::{
-        CompiledFunction, FunctionArgKind, FunctionArgs, FunctionDefinition,
+        AllFunction, CompiledFunction, FunctionArgKind, FunctionArgs, FunctionDefinition,
         FunctionDefinitionContext, FunctionParam, FunctionParamError, SimpleFunctionDefinition,
         SimpleFunctionImpl, SimpleFunctionOptParam, SimpleFunctionParam,
     };
@@ -967,6 +967,8 @@ mod tests {
             tcp.port: Int,
             tcp.ports: Array(Int),
             array.of.bool: Array(Bool),
+            map.bool.arr: Map(Array(Bool)),
+            map.bytes.arr: Map(Array(Bytes)),
             http.parts: Array(Array(Bytes)),
         };
         builder
@@ -983,6 +985,7 @@ mod tests {
                 },
             )
             .unwrap();
+        builder.add_function("all", AllFunction::default()).unwrap();
         builder
             .add_function(
                 "echo",
@@ -2631,6 +2634,34 @@ mod tests {
 
         ctx.set_field_value(field("tcp.ports"), arr2).unwrap();
         assert_eq!(expr.execute_one(ctx), false);
+    }
+
+    #[test]
+    fn test_any_all_functions_with_missing_arrays() {
+        let ctx = &mut ExecutionContext::new(&SCHEME);
+        ctx.set_field_value(
+            field("map.bool.arr"),
+            Map::new(Type::Array(Type::Bool.into())),
+        )
+        .unwrap();
+        ctx.set_field_value(
+            field("map.bytes.arr"),
+            Map::new(Type::Array(Type::Bytes.into())),
+        )
+        .unwrap();
+
+        let execute = |input| SCHEME.parse(input).unwrap().compile().execute(ctx).unwrap();
+
+        assert_eq!(execute(r#"any(map.bool.arr["missing"])"#), false);
+        assert_eq!(execute(r#"all(map.bool.arr["missing"])"#), false);
+        assert_eq!(
+            execute(r#"any(map.bytes.arr["missing"][*] matches "bar")"#),
+            false
+        );
+        assert_eq!(
+            execute(r#"all(map.bytes.arr["missing"][*] matches "bar")"#),
+            true
+        );
     }
 
     #[test]

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -799,9 +799,9 @@ mod tests {
     use crate::ast::logical_expr::LogicalExpr;
     use crate::execution_context::ExecutionContext;
     use crate::functions::{
-        FunctionArgKind, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
-        FunctionParam, FunctionParamError, SimpleFunctionDefinition, SimpleFunctionImpl,
-        SimpleFunctionOptParam, SimpleFunctionParam,
+        CompiledFunction, FunctionArgKind, FunctionArgs, FunctionDefinition,
+        FunctionDefinitionContext, FunctionParam, FunctionParamError, SimpleFunctionDefinition,
+        SimpleFunctionImpl, SimpleFunctionOptParam, SimpleFunctionParam,
     };
     use crate::lhs_types::{Array, Map};
     use crate::list_matcher::{ListDefinition, ListMatcher};
@@ -908,12 +908,7 @@ mod tests {
             &self,
             _: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
             _: Option<FunctionDefinitionContext>,
-        ) -> Box<
-            dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>>
-                + Sync
-                + Send
-                + 'static,
-        > {
+        ) -> CompiledFunction {
             Box::new(|args| {
                 let value_array = Array::try_from(args.next().unwrap().unwrap()).unwrap();
                 let keep_array = Array::try_from(args.next().unwrap().unwrap()).unwrap();

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -255,7 +255,8 @@ impl<'i, 's> LexWith<'i, &FilterParser<'s>> for IdentifierExpr {
         match item {
             Identifier::Field(field) => Ok((IdentifierExpr::Field(field.to_owned()), input)),
             Identifier::Function(function) => {
-                FunctionCallExpr::lex_with_function(input, parser, function)
+                let nested_parser = parser.with_increased_nesting(skip_space(input))?;
+                FunctionCallExpr::lex_with_function(input, &nested_parser, function)
                     .map(|(call, input)| (IdentifierExpr::FunctionCallExpr(call), input))
             }
         }

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -8,7 +8,7 @@ use crate::ast::logical_expr::{LogicalExpr, UnaryOp};
 use crate::compiler::Compiler;
 use crate::filter::{CompiledExpr, CompiledValueExpr, CompiledValueResult};
 use crate::functions::{
-    ExactSizeChain, FunctionArgs, FunctionDefinition, FunctionDefinitionContext, FunctionParam,
+    CompiledFunction, ExactSizeChain, FunctionDefinition, FunctionDefinitionContext, FunctionParam,
     FunctionParamError,
 };
 use crate::lex::{Lex, LexError, LexErrorKind, LexResult, LexWith, expect, skip_space, span};
@@ -272,11 +272,9 @@ impl ValueExpr for FunctionCallExpr {
             let first = args.remove(0);
 
             #[inline(always)]
-            fn compute<'s, 'a, I: ExactSizeIterator<Item = CompiledValueResult<'a>>>(
+            fn compute<'a, I: ExactSizeIterator<Item = CompiledValueResult<'a>>>(
                 first: CompiledValueResult<'a>,
-                call: &(
-                     dyn for<'b> Fn(FunctionArgs<'_, 'b>) -> Option<LhsValue<'b>> + Sync + Send + 's
-                 ),
+                call: &CompiledFunction,
                 return_type: Type,
                 f: impl Fn(LhsValue<'a>) -> I,
             ) -> CompiledValueResult<'a> {

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -512,8 +512,9 @@ impl GetType for FunctionCallExpr {
 impl<'i> LexWith<'i, &FilterParser<'_>> for FunctionCallExpr {
     fn lex_with(input: &'i str, parser: &FilterParser<'_>) -> LexResult<'i, Self> {
         let (function, rest) = FunctionRef::lex_with(input, parser.scheme)?;
+        let nested_parser = parser.with_increased_nesting(skip_space(rest))?;
 
-        Self::lex_with_function(rest, parser, function)
+        Self::lex_with_function(rest, &nested_parser, function)
     }
 }
 
@@ -564,6 +565,44 @@ mod tests {
 
     fn echo_function<'a>(args: FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> {
         args.next()?.ok()
+    }
+
+    #[test]
+    fn test_function_call_nesting_limit() {
+        let mut parser = FilterParser::new(&SCHEME);
+        parser.set_max_nesting_depth(2);
+
+        assert_err!(
+            parser.lex_as::<FunctionCallExpr>("echo ( echo ( echo ( http.host ) ) )"),
+            LexErrorKind::NestingLimitExceeded { limit: 2 },
+            "( http.host ) ) )"
+        );
+    }
+
+    #[test]
+    fn test_value_expr_function_call_nesting_limit() {
+        let mut parser = FilterParser::new(&SCHEME);
+        parser.set_max_nesting_depth(2);
+
+        assert_err!(
+            parser.lex_as::<crate::FilterValueAst>("echo ( echo ( echo ( http.host ) ) )"),
+            LexErrorKind::NestingLimitExceeded { limit: 2 },
+            "( http.host ) ) )"
+        );
+    }
+
+    #[test]
+    fn test_logical_argument_nesting_limit_is_counted_via_function_and_parentheses() {
+        let mut parser = FilterParser::new(&SCHEME);
+        parser.set_max_nesting_depth(1);
+
+        assert_err!(
+            parser.lex_as::<FunctionCallExpr>(
+                "any ( ( http.request.headers.is_empty or http.request.headers.is_empty ) )"
+            ),
+            LexErrorKind::NestingLimitExceeded { limit: 1 },
+            "( http.request.headers.is_empty or http.request.headers.is_empty ) )"
+        );
     }
 
     fn len_function<'a>(args: FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> {

--- a/engine/src/ast/logical_expr.rs
+++ b/engine/src/ast/logical_expr.rs
@@ -82,18 +82,20 @@ impl LogicalExpr {
     }
 
     fn lex_simple_expr<'i>(input: &'i str, parser: &FilterParser<'_>) -> LexResult<'i, Self> {
-        Ok(if let Ok(input) = expect(input, "(") {
-            let input = skip_space(input);
-            let (expr, input) = LogicalExpr::lex_with(input, parser)?;
+        Ok(if let Ok(rest) = expect(input, "(") {
+            let nested_parser = parser.with_increased_nesting(input)?;
+            let input = skip_space(rest);
+            let (expr, input) = LogicalExpr::lex_with(input, &nested_parser)?;
             let input = skip_space(input);
             let input = expect(input, ")")?;
             (
                 LogicalExpr::Parenthesized(Box::new(ParenthesizedExpr { expr })),
                 input,
             )
-        } else if let Ok((op, input)) = UnaryOp::lex(input) {
-            let input = skip_space(input);
-            let (arg, input) = Self::lex_simple_expr(input, parser)?;
+        } else if let Ok((op, rest)) = UnaryOp::lex(input) {
+            let nested_parser = parser.with_increased_nesting(input)?;
+            let input = skip_space(rest);
+            let (arg, input) = Self::lex_simple_expr(input, &nested_parser)?;
             (
                 LogicalExpr::Unary {
                     op,
@@ -550,6 +552,46 @@ fn test() {
         }
     );
 
+    assert_ok!(
+        FilterParser::new(scheme).lex_as("t and (t or t)"),
+        LogicalExpr::Combining {
+            op: LogicalOp::And,
+            items: vec![
+                t_expr(),
+                LogicalExpr::Parenthesized(Box::new(ParenthesizedExpr {
+                    expr: LogicalExpr::Combining {
+                        op: LogicalOp::Or,
+                        items: vec![t_expr(), t_expr()],
+                    },
+                })),
+            ],
+        }
+    );
+
+    assert_ok!(
+        FilterParser::new(scheme).lex_as("t and (t or (t and t))"),
+        LogicalExpr::Combining {
+            op: LogicalOp::And,
+            items: vec![
+                t_expr(),
+                LogicalExpr::Parenthesized(Box::new(ParenthesizedExpr {
+                    expr: LogicalExpr::Combining {
+                        op: LogicalOp::Or,
+                        items: vec![
+                            t_expr(),
+                            LogicalExpr::Parenthesized(Box::new(ParenthesizedExpr {
+                                expr: LogicalExpr::Combining {
+                                    op: LogicalOp::And,
+                                    items: vec![t_expr(), t_expr()],
+                                },
+                            })),
+                        ],
+                    },
+                })),
+            ],
+        }
+    );
+
     {
         let expr = assert_ok!(
             FilterParser::new(scheme).lex_as("at and af"),
@@ -878,6 +920,42 @@ fn test() {
         FilterParser::new(scheme).lex_as("! (not !at)"),
         not_expr(parenthesized_expr(not_expr(not_expr(at_expr()))))
     );
+
+    {
+        let mut parser = FilterParser::new(scheme);
+        parser.set_max_nesting_depth(1);
+        assert_err!(
+            parser.lex_as::<LogicalExpr>("((t))"),
+            LexErrorKind::NestingLimitExceeded { limit: 1 },
+            "(t))"
+        );
+    }
+
+    {
+        let mut parser = FilterParser::new(scheme);
+        parser.set_max_nesting_depth(1);
+        assert_err!(
+            parser.lex_as::<LogicalExpr>("!!t"),
+            LexErrorKind::NestingLimitExceeded { limit: 1 },
+            "!t"
+        );
+    }
+
+    {
+        let mut parser = FilterParser::new(scheme);
+        parser.set_max_nesting_depth(2);
+        assert_ok!(parser.lex_as("!!t"), not_expr(not_expr(t_expr())));
+    }
+
+    {
+        let mut parser = FilterParser::new(scheme);
+        parser.set_max_nesting_depth(0);
+        assert_err!(
+            parser.lex_as::<LogicalExpr>("t and (t or t)"),
+            LexErrorKind::NestingLimitExceeded { limit: 0 },
+            "(t or t)"
+        );
+    }
 
     {
         let expr = assert_ok!(

--- a/engine/src/ast/parse.rs
+++ b/engine/src/ast/parse.rs
@@ -106,6 +106,9 @@ pub struct ParserSettings {
     /// Maximum number of star metacharacters allowed in a wildcard.
     /// Default: unlimited
     pub wildcard_star_limit: usize,
+    /// Maximum nesting depth allowed while parsing.
+    /// Default: 128
+    pub max_nesting_depth: u16,
 }
 
 impl Default for ParserSettings {
@@ -117,6 +120,7 @@ impl Default for ParserSettings {
             // Default value extracted from the regex crate.
             regex_dfa_size_limit: 2 * (1 << 20),
             wildcard_star_limit: usize::MAX,
+            max_nesting_depth: 128,
         }
     }
 }
@@ -126,6 +130,7 @@ impl Default for ParserSettings {
 pub struct FilterParser<'s> {
     pub(crate) scheme: &'s Scheme,
     pub(crate) settings: ParserSettings,
+    current_nesting_depth: u16,
 }
 
 impl<'s> FilterParser<'s> {
@@ -135,13 +140,18 @@ impl<'s> FilterParser<'s> {
         Self {
             scheme,
             settings: ParserSettings::default(),
+            current_nesting_depth: 0,
         }
     }
 
     /// Creates a new parser with the specified settings.
     #[inline]
     pub fn with_settings(scheme: &'s Scheme, settings: ParserSettings) -> Self {
-        Self { scheme, settings }
+        Self {
+            scheme,
+            settings,
+            current_nesting_depth: 0,
+        }
     }
 
     /// Returns the [`Scheme`](struct@Scheme) for which this parser has been constructor for.
@@ -156,6 +166,25 @@ impl<'s> FilterParser<'s> {
         input: &'i str,
     ) -> LexResult<'i, L> {
         L::lex_with(input, self)
+    }
+
+    #[inline]
+    pub(crate) fn with_increased_nesting<'i>(
+        &self,
+        span: &'i str,
+    ) -> Result<Self, (LexErrorKind, &'i str)> {
+        if self.current_nesting_depth >= self.settings.max_nesting_depth {
+            Err((
+                LexErrorKind::NestingLimitExceeded {
+                    limit: self.settings.max_nesting_depth,
+                },
+                span,
+            ))
+        } else {
+            let mut nested = self.clone();
+            nested.current_nesting_depth += 1;
+            Ok(nested)
+        }
     }
 
     /// Parses a filter expression into an AST form.
@@ -208,5 +237,17 @@ impl<'s> FilterParser<'s> {
     #[inline]
     pub fn wildcard_get_star_limit(&self) -> usize {
         self.settings.wildcard_star_limit
+    }
+
+    /// Set the maximum nesting depth allowed while parsing.
+    #[inline]
+    pub fn set_max_nesting_depth(&mut self, max_nesting_depth: u16) {
+        self.settings.max_nesting_depth = max_nesting_depth;
+    }
+
+    /// Get the maximum nesting depth allowed while parsing.
+    #[inline]
+    pub fn max_nesting_depth(&self) -> u16 {
+        self.settings.max_nesting_depth
     }
 }

--- a/engine/src/functions/all.rs
+++ b/engine/src/functions/all.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use std::iter::once;
 
-#[inline]
 fn all_impl<'a>(args: FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> {
     let arg = args.next().expect("expected 1 argument, got 0");
     if args.next().is_some() {

--- a/engine/src/functions/all.rs
+++ b/engine/src/functions/all.rs
@@ -1,6 +1,6 @@
 use crate::{
-    FunctionArgKind, FunctionArgs, FunctionDefinition, FunctionDefinitionContext, FunctionParam,
-    FunctionParamError, GetType, LhsValue, ParserSettings, Type,
+    CompiledFunction, FunctionArgKind, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
+    FunctionParam, FunctionParamError, GetType, LhsValue, ParserSettings, Type,
 };
 use std::iter::once;
 
@@ -58,12 +58,11 @@ impl FunctionDefinition for AllFunction {
         (1, Some(0))
     }
 
-    fn compile<'s>(
-        &'s self,
+    fn compile(
+        &self,
         _: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         _: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>
-    {
+    ) -> CompiledFunction {
         Box::new(all_impl)
     }
 }

--- a/engine/src/functions/any.rs
+++ b/engine/src/functions/any.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use std::iter::once;
 
-#[inline]
 fn any_impl<'a>(args: FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> {
     let arg = args.next().expect("expected 1 argument, got 0");
     if args.next().is_some() {

--- a/engine/src/functions/any.rs
+++ b/engine/src/functions/any.rs
@@ -1,6 +1,6 @@
 use crate::{
-    FunctionArgKind, FunctionArgs, FunctionDefinition, FunctionDefinitionContext, FunctionParam,
-    FunctionParamError, GetType, LhsValue, ParserSettings, Type,
+    CompiledFunction, FunctionArgKind, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
+    FunctionParam, FunctionParamError, GetType, LhsValue, ParserSettings, Type,
 };
 use std::iter::once;
 
@@ -58,12 +58,11 @@ impl FunctionDefinition for AnyFunction {
         (1, Some(0))
     }
 
-    fn compile<'s>(
-        &'s self,
+    fn compile(
+        &self,
         _: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         _: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>
-    {
+    ) -> CompiledFunction {
         Box::new(any_impl)
     }
 }

--- a/engine/src/functions/concat.rs
+++ b/engine/src/functions/concat.rs
@@ -20,6 +20,7 @@ impl ConcatFunction {
     }
 }
 
+#[inline]
 fn concat_array<'a>(accumulator: Array<'a>, args: FunctionArgs<'_, 'a>) -> Array<'a> {
     let mut args = args.flat_map(|arg| arg.ok());
     let Some(first) = args.next() else {
@@ -44,6 +45,7 @@ fn concat_array<'a>(accumulator: Array<'a>, args: FunctionArgs<'_, 'a>) -> Array
     Array::try_from_vec(val_type, vec).unwrap()
 }
 
+#[inline]
 fn concat_bytes<'a>(mut accumulator: Vec<u8>, args: FunctionArgs<'_, 'a>) -> Bytes<'a> {
     for arg in args {
         match arg {
@@ -53,6 +55,25 @@ fn concat_bytes<'a>(mut accumulator: Vec<u8>, args: FunctionArgs<'_, 'a>) -> Byt
         }
     }
     accumulator.into()
+}
+
+fn concat_impl<'a>(args: FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> {
+    while let Some(arg) = args.next() {
+        match arg {
+            Ok(LhsValue::Array(array)) => {
+                return Some(LhsValue::Array(concat_array(array, args)));
+            }
+            Ok(LhsValue::Bytes(bytes)) => {
+                return Some(LhsValue::Bytes(concat_bytes(
+                    bytes.into_owned().into(),
+                    args,
+                )));
+            }
+            Err(_) => (),
+            _ => unreachable!(),
+        }
+    }
+    None
 }
 
 pub(crate) const EXPECTED_TYPES: [ExpectedType; 2] =
@@ -96,24 +117,7 @@ impl FunctionDefinition for ConcatFunction {
         _: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         _: Option<FunctionDefinitionContext>,
     ) -> CompiledFunction {
-        Box::new(|args| {
-            while let Some(arg) = args.next() {
-                match arg {
-                    Ok(LhsValue::Array(array)) => {
-                        return Some(LhsValue::Array(concat_array(array, args)));
-                    }
-                    Ok(LhsValue::Bytes(bytes)) => {
-                        return Some(LhsValue::Bytes(concat_bytes(
-                            bytes.into_owned().into(),
-                            args,
-                        )));
-                    }
-                    Err(_) => (),
-                    _ => unreachable!(),
-                }
-            }
-            None
-        })
+        Box::new(concat_impl)
     }
 }
 
@@ -133,7 +137,7 @@ mod tests {
         .into_iter();
         assert_eq!(
             Some(LhsValue::Bytes(Bytes::Borrowed(b"helloworld"))),
-            CONCAT_FN.compile(&mut std::iter::empty(), None)(&mut args)
+            concat_impl(&mut args)
         );
     }
 
@@ -148,7 +152,7 @@ mod tests {
         .into_iter();
         assert_eq!(
             Some(LhsValue::Bytes(Bytes::Borrowed(b"helloworldhello2world2"))),
-            CONCAT_FN.compile(&mut std::iter::empty(), None)(&mut args)
+            concat_impl(&mut args)
         );
     }
 
@@ -159,7 +163,7 @@ mod tests {
         let mut args = vec![Ok(arg1), Ok(arg2)].into_iter();
         assert_eq!(
             Some(LhsValue::Array(Array::from_iter([1, 2, 3, 4, 5, 6]))),
-            CONCAT_FN.compile(&mut std::iter::empty(), None)(&mut args)
+            concat_impl(&mut args)
         );
     }
 
@@ -167,7 +171,7 @@ mod tests {
     #[should_panic]
     fn test_concat_function_bad_arg_type() {
         let mut args = vec![Ok(LhsValue::from(2))].into_iter();
-        CONCAT_FN.compile(&mut std::iter::empty(), None)(&mut args);
+        concat_impl(&mut args);
     }
 
     #[test]

--- a/engine/src/functions/concat.rs
+++ b/engine/src/functions/concat.rs
@@ -1,6 +1,7 @@
 use crate::{
-    Array, Bytes, ExpectedType, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
-    FunctionParam, FunctionParamError, GetType, LhsValue, ParserSettings, Type,
+    Array, Bytes, CompiledFunction, ExpectedType, FunctionArgs, FunctionDefinition,
+    FunctionDefinitionContext, FunctionParam, FunctionParamError, GetType, LhsValue,
+    ParserSettings, Type,
 };
 use std::iter::once;
 
@@ -90,12 +91,11 @@ impl FunctionDefinition for ConcatFunction {
         (2, None)
     }
 
-    fn compile<'s>(
-        &'s self,
+    fn compile(
+        &self,
         _: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         _: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>
-    {
+    ) -> CompiledFunction {
         Box::new(|args| {
             while let Some(arg) = args.next() {
                 match arg {

--- a/engine/src/functions/mod.rs
+++ b/engine/src/functions/mod.rs
@@ -373,6 +373,13 @@ impl std::fmt::Debug for FunctionDefinitionContext {
     }
 }
 
+/// A compiled function that can be called during filter execution.
+///
+/// Returned by [`FunctionDefinition::compile`] after a function call expression
+/// has been validated and compiled.
+pub type CompiledFunction =
+    Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>;
+
 /// Trait to implement function
 pub trait FunctionDefinition: Debug + Send + Sync {
     /// Custom context to store information during parsing
@@ -404,7 +411,7 @@ pub trait FunctionDefinition: Debug + Send + Sync {
         &self,
         params: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         ctx: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>;
+    ) -> CompiledFunction;
 }
 
 // Simple function APIs
@@ -530,8 +537,7 @@ impl FunctionDefinition for SimpleFunctionDefinition {
         &self,
         params: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         _: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>
-    {
+    ) -> CompiledFunction {
         let params_count = params.len();
         let opt_params = &self.opt_params[(params_count - self.params.len())..];
         let implementation = self.implementation;

--- a/engine/src/lex.rs
+++ b/engine/src/lex.rs
@@ -150,6 +150,13 @@ pub enum LexErrorKind {
         /// Name of the list
         name: String,
     },
+
+    /// Maximum nesting depth exceeded while parsing.
+    #[error("maximum nesting depth exceeded (limit: {limit})")]
+    NestingLimitExceeded {
+        /// The configured maximum nesting depth.
+        limit: u16,
+    },
 }
 
 pub type LexError<'i> = (LexErrorKind, &'i str);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -96,10 +96,10 @@ pub use self::filter::{
     CompiledExpr, CompiledOneExpr, CompiledValueExpr, CompiledVecExpr, Filter, FilterValue,
 };
 pub use self::functions::{
-    AllFunction, AnyFunction, ConcatFunction, FunctionArgInvalidConstantError, FunctionArgKind,
-    FunctionArgKindMismatchError, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
-    FunctionParam, FunctionParamError, SimpleFunctionArgKind, SimpleFunctionDefinition,
-    SimpleFunctionImpl, SimpleFunctionOptParam, SimpleFunctionParam,
+    AllFunction, AnyFunction, CompiledFunction, ConcatFunction, FunctionArgInvalidConstantError,
+    FunctionArgKind, FunctionArgKindMismatchError, FunctionArgs, FunctionDefinition,
+    FunctionDefinitionContext, FunctionParam, FunctionParamError, SimpleFunctionArgKind,
+    SimpleFunctionDefinition, SimpleFunctionImpl, SimpleFunctionOptParam, SimpleFunctionParam,
 };
 pub use self::lex::LexErrorKind;
 pub use self::lhs_types::{Array, Bytes, Map, MapIter, TypedArray, TypedMap};


### PR DESCRIPTION
## Summary
Merges upstream `cloudflare/wirefilter:master` into the gen0sec fork, resolving the conflicts that block #21. Opened as a same-repo branch because #21's head lives in `cloudflare/wirefilter` and can't be pushed to directly.

Upstream commits pulled in:
- Bump rand 0.9.2 → 0.9.3
- ci: add Semgrep OSS scanning workflow
- Add parser nesting depth limit
- Add `CompiledFunction` type alias
- Extract `_impl` functions
- Add any/all missing array tests

## Conflict resolution
- `Cargo.toml` — kept the gen0sec `outer-regex` dependency (required by the fork's custom regex functions).
- `engine/src/lib.rs` — merged the `functions` export lists: kept all gen0sec custom functions and added upstream's `CompiledFunction`.
- `Cargo.lock` — regenerated.

The fork's custom functions remain compatible since `CompiledFunction` is just an alias for the `compile()` return type they already use.

## Test plan
- [x] `cargo build` (full workspace)
- [x] `cargo clippy --all-targets -- -D clippy::all` clean
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo test` — all pass (253 tests, incl. upstream's new array tests)

Once merged, close #21.